### PR TITLE
Feat pulsar sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Zipkin Reporter buffers and sends trace data collected from tracer libraries to a Zipkin compatible backend.
 
 This repository includes a Java reporting library with transport-specific senders.
-Transport options include HTTP, Apache ActiveMQ, Apache Kafka, gRPC, RabbitMQ
-and Scribe (Apache Thrift). Requires JRE 6 or later.
+Transport options include HTTP, Apache ActiveMQ, Apache Kafka, gRPC, RabbitMQ, Scribe (Apache Thrift)
+and Apache Pulsar. Requires JRE 6 or later.
 
 # Usage
 These components can be called when spans have been recorded and ready to send to zipkin.

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>zipkin-reporter-parent</artifactId>
     <groupId>io.zipkin.reporter2</groupId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQContainer.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQContainer.java
@@ -19,7 +19,7 @@ final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
   static final int ACTIVEMQ_PORT = 61616;
 
   ActiveMQContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-activemq:3.1.1"));
+    super(parse("ghcr.io/openzipkin/zipkin-activemq:3.4.3"));
     withExposedPorts(ACTIVEMQ_PORT);
     waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
     withStartupTimeout(Duration.ofSeconds(60));

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-amqp-client</artifactId>

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQContainer.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQContainer.java
@@ -20,7 +20,7 @@ final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
   static final int RABBIT_PORT = 5672;
 
   RabbitMQContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.1.1"));
+    super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.4.3"));
     withExposedPorts(RABBIT_PORT);
     waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
     withStartupTimeout(Duration.ofSeconds(60));

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -109,6 +109,12 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-pulsar-client</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/benchmarks/src/test/java/zipkin2/reporter/KafkaSenderBenchmarks.java
+++ b/benchmarks/src/test/java/zipkin2/reporter/KafkaSenderBenchmarks.java
@@ -33,7 +33,7 @@ public class KafkaSenderBenchmarks extends SenderBenchmarks {
 
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.1"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.4.3"));
       waitStrategy = Wait.forHealthcheck();
       // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
       addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/benchmarks/src/test/java/zipkin2/reporter/PulsarSenderBenchmarks.java
+++ b/benchmarks/src/test/java/zipkin2/reporter/PulsarSenderBenchmarks.java
@@ -34,7 +34,7 @@ public class PulsarSenderBenchmarks extends SenderBenchmarks {
     static final int BROKER_HTTP_PORT = 8080;
 
     PulsarContainer() {
-      super(parse("apachepulsar/pulsar:4.0.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-pulsar:3.4.3"));
       withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
       String cmd = "/pulsar/bin/apply-config-from-env.py /pulsar/conf/standalone.conf " +
           "&& bin/pulsar standalone " +

--- a/benchmarks/src/test/java/zipkin2/reporter/PulsarSenderBenchmarks.java
+++ b/benchmarks/src/test/java/zipkin2/reporter/PulsarSenderBenchmarks.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import zipkin2.reporter.internal.SenderBenchmarks;
+import zipkin2.reporter.pulsar.PulsarSender;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.testcontainers.utility.DockerImageName.parse;
+
+public class PulsarSenderBenchmarks extends SenderBenchmarks {
+  static final Logger LOGGER = LoggerFactory.getLogger(PulsarSenderBenchmarks.class);
+
+  static final class PulsarContainer extends GenericContainer<PulsarContainer> {
+    static final int BROKER_PORT = 6650;
+    static final int BROKER_HTTP_PORT = 8080;
+
+    PulsarContainer() {
+      super(parse("apachepulsar/pulsar:4.0.2"));
+      withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
+      String cmd = "/pulsar/bin/apply-config-from-env.py /pulsar/conf/standalone.conf " +
+          "&& bin/pulsar standalone " +
+          "--no-functions-worker -nss";
+      withEnv("PULSAR_MEM", "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=1g"); // limit memory usage
+      waitStrategy = new HttpWaitStrategy()
+          .forPort(BROKER_HTTP_PORT)
+          .forStatusCode(200)
+          .forPath("/admin/v2/clusters")
+          .withStartupTimeout(Duration.ofSeconds(120));
+      withCommand("/bin/bash", "-c", cmd);
+      withLogConsumer(new Slf4jLogConsumer(LOGGER));
+    }
+
+    String serviceUrl() {
+      return "pulsar://" + getHost() + ":" + getMappedPort(BROKER_PORT);
+    }
+  }
+
+  PulsarContainer pulsar;
+  Consumer<byte[]> consumer;
+
+  @Override protected BytesMessageSender createSender() throws PulsarClientException {
+    pulsar = new PulsarContainer();
+    pulsar.start();
+
+    String topicName = "zipkin";
+    PulsarSender sender = PulsarSender.newBuilder().topic(topicName)
+        .serviceUrl(pulsar.serviceUrl()).build();
+
+    sender.send(Collections.emptyList());
+    try (PulsarClient client = PulsarClient.builder()
+        .serviceUrl(pulsar.serviceUrl())
+        .build()) {
+      consumer = client.newConsumer()
+          .topic(topicName)
+          .subscriptionType(SubscriptionType.Shared)
+          .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+          .subscriptionName(topicName)
+          .subscribe();
+    }
+
+    return sender;
+  }
+
+  @Override protected void afterSenderClose() {
+    pulsar.stop();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + PulsarSenderBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}
+

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -136,6 +136,11 @@
         <artifactId>zipkin-reporter-metrics-micrometer</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-pulsar-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-bom</artifactId>
   <name>Zipkin Reporter BOM</name>
-  <version>3.4.4-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Bill Of Materials POM for all Zipkin reporter artifacts</description>
 

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter</artifactId>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka</artifactId>

--- a/kafka/src/test/java/zipkin2/reporter/kafka/KafkaContainer.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/KafkaContainer.java
@@ -28,7 +28,7 @@ final class KafkaContainer extends GenericContainer<KafkaContainer> {
   static final int KAFKA_PORT = 19092;
 
   KafkaContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.1"));
+    super(parse("ghcr.io/openzipkin/zipkin-kafka:3.4.3"));
     waitStrategy = Wait.forHealthcheck();
     // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
     addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-libthrift</artifactId>

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinContainer.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinContainer.java
@@ -22,7 +22,7 @@ final class ZipkinContainer extends GenericContainer<ZipkinContainer> {
   static final int HTTP_PORT = 9411;
 
   ZipkinContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin:3.1.1"));
+    super(parse("ghcr.io/openzipkin/zipkin:3.4.3"));
     // zipkin-server disables scribe by default.
     withEnv("COLLECTOR_SCRIBE_ENABLED", "true");
     withExposedPorts(SCRIBE_PORT, HTTP_PORT);

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter-metrics-micrometer</artifactId>

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-okhttp3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-parent</artifactId>
-  <version>3.4.4-SNAPSHOT</version>
+  <version>3.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>spring-beans</module>
     <module>brave</module>
     <module>metrics-micrometer</module>
+    <module>pulsar-client</module>
   </modules>
 
   <properties>

--- a/pulsar-client/bnd.bnd
+++ b/pulsar-client/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+  zipkin2.reporter.pulsar

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <groupId>io.zipkin.reporter2</groupId>
+    <version>3.4.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-sender-pulsar-client</artifactId>
+  <name>Zipkin Sender: Pulsar Client 4.x</name>
+
+  <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>zipkin2.reporter.pulsar</module.name>
+
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <pulsar-client.version>4.0.2</pulsar-client.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
+      <!-- Senders don't use zipkin types. Excluding allows brave users to
+           avoid them by default. -->
+      <exclusions>
+        <exclusion>
+          <groupId>io.zipkin.zipkin2</groupId>
+          <artifactId>zipkin</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client</artifactId>
+      <version>${pulsar-client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+        <!-- pulsar 4.0+ is Java 8 bytecode -->
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>${maven-enforcer-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <!-- The only LTS JDK we support that can compile 8 bytecode is 11.
+                         https://www.oracle.com/java/technologies/javase/17-relnote-issues.html -->
+                    <requireJavaVersion>
+                      <version>[11,12)</version>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <artifactId>zipkin-reporter-parent</artifactId>
     <groupId>io.zipkin.reporter2</groupId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-pulsar-client</artifactId>

--- a/pulsar-client/src/main/java/zipkin2/reporter/pulsar/PulsarSender.java
+++ b/pulsar-client/src/main/java/zipkin2/reporter/pulsar/PulsarSender.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.pulsar;
+
+import io.opentelemetry.api.internal.StringUtils;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.Sender;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This sends (usually json v2) encoded spans to a Pulsar topic.
+ *
+ * <h3>Usage</h3>
+ * <p>
+ * This type is designed for {@link AsyncReporter.Builder#builder(BytesMessageSender) the async
+ * reporter}.
+ *
+ * <p>Here's a simple configuration, configured for json:
+ *
+ * <pre>{@code
+ * sender = PulsarSender.create("pulsar://localhost:6650");
+ * }</pre>
+ *
+ * <p>Here's to customize the required configuration for pulsar's
+ * client, produce, and message, or override the default configuration:
+ *
+ * <pre>{@code
+ * Map<String, Object> clientPropsMap = new HashMap<>();
+ * clientPropsMap.put("numIoThreads", 20);
+ * Map<String, Object> producerPropsMap = new HashMap<>();
+ * producerPropsMap.put("producerName", "zipkin");
+ * Map<String, Object> messagePropsMap = new HashMap<>();
+ * messagePropsMap.put("key", "zipkin-key");
+ * sender = PulsarSender.newBuilder()
+ *   .serviceUrl("pulsar://localhost:6650")
+ *   .topic("zipkin")
+ *   .clientProps(clientPropsMap)
+ *   .producerProps(producerPropsMap)
+ *   .messageProps(messagePropsMap)
+ *   .encoding(Encoding.PROTO3)
+ *   .build();
+ * }</pre>
+ *
+ * <h3>Compatibility with Zipkin Server</h3>
+ *
+ * <a href="https://github.com/openzipkin/zipkin">Zipkin server</a> should be v2.1 or higher.
+ *
+ * <h3>Implementation Notes</h3>
+ *
+ * <p>This sender is thread-safe.<p>
+ * <p>clientProps {@link org.apache.pulsar.client.impl.conf.ClientConfigurationData}<p>
+ * <p>producerProps {@link org.apache.pulsar.client.impl.conf.ProducerConfigurationData}<p>
+ * <p>messageProps {@link org.apache.pulsar.client.api.TypedMessageBuilder}<p>
+ */
+public final class PulsarSender extends Sender {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PulsarSender.class);
+
+  /** Creates a sender that sends {@link Encoding#JSON} messages. */
+  public static PulsarSender create(String serviceUrl) {
+    return newBuilder().serviceUrl(serviceUrl).build();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    Map<String, Object> clientProps = new HashMap<>(),
+        producerProps = new HashMap<>(), messageProps = new HashMap<>();
+    String topic = "zipkin";
+    Encoding encoding = Encoding.JSON;
+    int messageMaxBytes = 500_000;
+
+    public PulsarSender build() {
+      return new PulsarSender(this);
+    }
+
+    Builder() {
+    }
+
+    /** The service URL for the Pulsar client ex. pulsar://my-broker:6650. No default. */
+    public Builder serviceUrl(String serviceUrl) {
+      if (StringUtils.isNullOrEmpty(serviceUrl)) throw new NullPointerException("serviceUrl is null or empty");
+      clientProps.put("serviceUrl", serviceUrl);
+      return this;
+    }
+
+    /** Specify the topic this producer will be publishing on. Defaults to "zipkin" */
+    public Builder topic(String topic) {
+      if (StringUtils.isNullOrEmpty(topic)) throw new NullPointerException("topic is null or empty");
+      this.topic = topic;
+      return this;
+    }
+
+    /**
+     * Maximum size of a message. Must be equal to or less than the broker's "maxMessageSize" to
+     * avoid rejected records on the broker side. Default 500KB.
+     */
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      this.messageMaxBytes = messageMaxBytes;
+      producerProps.put("batchingMaxBytes", messageMaxBytes);
+      return this;
+    }
+
+    /**
+     * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
+     *
+     * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
+     */
+    public Builder encoding(Encoding encoding) {
+      if (encoding == null) throw new NullPointerException("encoding == null");
+      this.encoding = encoding;
+      return this;
+    }
+
+    /**
+     * Load the configuration from provided <tt>config</tt> map.
+     * Any properties set here will override the previous Pulsar client configuration.
+     *
+     * <p>For example:
+     * <pre>{@code
+     * Map<String, Object> clientPropsMap = new HashMap<>();
+     * clientPropsMap.put("numIoThreads", 20);
+     * builder.clientProps(clientPropsMap);
+     * }</pre>
+     *
+     * @param clientPropsMap Map<String, Object>
+     * @return Builder
+     * @see org.apache.pulsar.client.impl.conf.ClientConfigurationData
+     */
+    public Builder clientProps(Map<String, Object> clientPropsMap) {
+      if (clientPropsMap.isEmpty()) throw new NullPointerException("clientProps is empty");
+      clientProps.putAll(clientPropsMap);
+      return this;
+    }
+
+    /**
+     * By default, a producer will be created, targeted to {@link #serviceUrl(String)}
+     * Any properties set here will override the previous Pulsar producer configuration.
+     * <p>
+     * Consider not overriding batching properties `enableBatching=false` as it will
+     * duplicate buffering effort that is already handled by Sender.
+     *
+     * <p>For example: Config the producerName.
+     * <pre>{@code
+     * Map<String, Object> producerPropsMap = new HashMap<>();
+     * producerPropsMap.put("producerName", "zipkin");
+     * builder.producerProps(producerPropsMap);
+     * }</pre>
+     *
+     * @param producerPropsMap Map<String, Object>
+     * @return Builder
+     * @see org.apache.pulsar.client.impl.conf.ProducerConfigurationData
+     */
+    public Builder producerProps(Map<String, Object> producerPropsMap) {
+      if (producerPropsMap.isEmpty()) throw new NullPointerException("producerProps is empty");
+      producerProps.putAll(producerPropsMap);
+      return this;
+    }
+
+    /**
+     * Configure messages.
+     * Any properties set here will override the previous Pulsar message configuration.
+     *
+     * <p>For example: Set various properties of Pulsar's messages.
+     * <pre>{@code
+     * Map<String, Object> messagePropsMap = new HashMap<>();
+     * messagePropsMap.put("key", "zipkin-key");
+     * messagePropsMap.put("eventTime", System.currentTimeMillis());
+     * builder.messageProps(messagePropsMap);
+     * }</pre>
+     *
+     * @param messagePropsMap Map<String, Object>
+     * @return Builder
+     * @see org.apache.pulsar.client.impl.TypedMessageBuilderImpl#loadConf
+     */
+    public Builder messageProps(Map<String, Object> messagePropsMap) {
+      if (messagePropsMap.isEmpty()) throw new NullPointerException("messageProps is empty");
+      messageProps.putAll(messagePropsMap);
+      return this;
+    }
+  }
+
+  final Map<String, Object> clientProps, producerProps, messageProps;
+  final String topic;
+  final Encoding encoding;
+  final int messageMaxBytes;
+
+  PulsarSender(Builder builder) {
+    clientProps = builder.clientProps;
+    producerProps = builder.producerProps;
+    messageProps = builder.messageProps;
+    topic = builder.topic;
+    encoding = builder.encoding;
+    messageMaxBytes = builder.messageMaxBytes;
+  }
+
+  volatile boolean closeCalled;
+  volatile Producer<byte[]> producer;
+  volatile PulsarClient client;
+
+  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
+    return encoding.listSizeInBytes(encodedSpans);
+  }
+
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding.listSizeInBytes(encodedSizeInBytes);
+  }
+
+  @Override public Encoding encoding() {
+    return encoding;
+  }
+
+  @Override public int messageMaxBytes() {
+    return messageMaxBytes;
+  }
+
+  /** {@inheritDoc} */
+  @Override @Deprecated public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+    if (closeCalled) throw new ClosedSenderException();
+    byte[] message = encoding.encode(encodedSpans);
+    return new PulsarCall(message);
+  }
+
+  @Override public void send(List<byte[]> encodedSpans) {
+    if (closeCalled) throw new ClosedSenderException();
+    sender(encoding.encode(encodedSpans));
+  }
+
+  void sender(byte[] message) {
+    if (closeCalled) throw new ClosedSenderException();
+    createIfNeeded(message);
+  }
+
+  void createIfNeeded(byte[] message) {
+    if (client == null) {
+      synchronized (this) {
+        if (client == null) {
+          try {
+            client = PulsarClient.builder()
+                .loadConf(clientProps)
+                .build();
+          } catch (PulsarClientException e) {
+            throw new RuntimeException("Pulsar client creation failed. " + e.getMessage(), e);
+          }
+
+          try {
+            producer = client.newProducer()
+                .topic(topic)
+                .enableBatching(false) // disabling batching as duplicates effort covered by sender buffering.
+                .loadConf(producerProps)
+                .create();
+          } catch (Exception e) {
+            try {
+              client.close();
+              client = null;
+            } catch (PulsarClientException ignored) {
+            }
+            throw new RuntimeException("Pulsar producer creation failed." + e.getMessage(), e);
+          }
+
+          try {
+            CompletableFuture<MessageId> messageIdFuture = producer
+                .newMessage()
+                .value(message)
+                .loadConf(messageProps)
+                .sendAsync();
+            messageIdFuture.whenComplete((messageId, t) -> {
+              if (t != null) {
+                LOG.error("Failed to send message to Pulsar", t);
+              } else {
+                LOG.debug("Message sent to Pulsar, the messageId is {}", messageId);
+              }
+            });
+          } catch (Exception e) {
+            throw new RuntimeException("Pulsar producer send failed." + e.getMessage(), e);
+          }
+        }
+      }
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override @Deprecated public CheckResult check() {
+    try {
+      client.getPartitionsForTopic(topic).get(15, TimeUnit.SECONDS);
+    } catch (Throwable t) {
+      Call.propagateIfFatal(t);
+      return CheckResult.failed(t);
+    }
+    return CheckResult.OK;
+  }
+
+  @Override public synchronized void close() throws IOException {
+    if (closeCalled) return;
+    PulsarClient client = this.client;
+    if (client != null) client.close();
+    Producer<byte[]> producer = this.producer;
+    if (producer != null) producer.close();
+    closeCalled = true;
+  }
+
+  @Override public String toString() {
+    return "PulsarSender{" +
+        "clientProps=" + clientProps +
+        ", producerProps=" + producerProps +
+        ", messageProps=" + messageProps +
+        ", topic=" + topic +
+        '}';
+  }
+
+  class PulsarCall extends Call.Base<Void> {  // PulsarCall is not cancelable
+    private final byte[] message;
+
+    PulsarCall(byte[] message) {
+      this.message = message;
+    }
+
+    @Override protected Void doExecute() throws IOException {
+      sender(message);
+      return null;
+    }
+
+    @Override protected void doEnqueue(Callback<Void> callback) {
+      try {
+        sender(message);
+        callback.onSuccess(null);
+      } catch (Throwable t) {
+        Call.propagateIfFatal(t);
+        callback.onError(t);
+      }
+    }
+
+    @Override public Call<Void> clone() {
+      return new PulsarCall(message);
+    }
+  }
+}

--- a/pulsar-client/src/main/java/zipkin2/reporter/pulsar/PulsarSender.java
+++ b/pulsar-client/src/main/java/zipkin2/reporter/pulsar/PulsarSender.java
@@ -324,10 +324,7 @@ public final class PulsarSender extends Sender {
 
   @Override public synchronized void close() throws IOException {
     if (closeCalled) return;
-    PulsarClient client = this.client;
-    if (client != null) client.close();
-    Producer<byte[]> producer = this.producer;
-    if (producer != null) producer.close();
+    cleanup();
     closeCalled = true;
   }
 

--- a/pulsar-client/src/test/java/zipkin2/reporter/pulsar/ITPulsarSender.java
+++ b/pulsar-client/src/test/java/zipkin2/reporter/pulsar/ITPulsarSender.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.pulsar;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.SpanBytesEncoder;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+
+@Tag("docker")
+@Testcontainers(disabledWithoutDocker = true)
+@Timeout(60)
+class ITPulsarSender {
+
+  @Container
+  PulsarContainer pulsar = new PulsarContainer();
+  String testName;
+
+  @BeforeEach void start(TestInfo testInfo) throws Exception {
+    Optional<Method> testMethod = testInfo.getTestMethod();
+    testMethod.ifPresent(method -> this.testName = method.getName());
+    Thread.sleep(2000); // wait for pulsar to start completely
+  }
+
+  @Test void emptyOk() throws IOException {
+    try (PulsarSender sender = pulsar.newSenderBuilder(testName).build()) {
+      sender.send(Collections.emptyList());
+    }
+  }
+
+  @Test void sendFailsWithInvalidPulsarServer() throws IOException {
+    try (PulsarSender sender = PulsarSender.create("@zixin")) {
+      assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("Pulsar client creation failed.");
+    }
+  }
+
+  @Test void send_JSON() throws Exception {
+    try (PulsarSender sender = pulsar.newSenderBuilder(testName)
+        .encoding(Encoding.JSON)
+        .build()) {
+      send(sender, CLIENT_SPAN, CLIENT_SPAN);
+
+      assertThat(SpanBytesDecoder.JSON_V2.decodeList(readMessage(sender))).containsExactly(
+          CLIENT_SPAN, CLIENT_SPAN);
+    }
+  }
+
+  @Test void send_PROTO3() throws Exception {
+    try (PulsarSender sender = pulsar.newSenderBuilder(testName)
+        .encoding(Encoding.PROTO3)
+        .build()) {
+      send(sender, CLIENT_SPAN, CLIENT_SPAN);
+
+      assertThat(SpanBytesDecoder.PROTO3.decodeList(readMessage(sender))).containsExactly(
+          CLIENT_SPAN, CLIENT_SPAN);
+    }
+  }
+
+  @Test void send_THRIFT() throws Exception {
+    try (PulsarSender sender = pulsar.newSenderBuilder(testName)
+        .encoding(Encoding.THRIFT)
+        .build()) {
+      send(sender, CLIENT_SPAN, CLIENT_SPAN);
+
+      assertThat(SpanBytesDecoder.THRIFT.decodeList(readMessage(sender))).containsExactly(
+          CLIENT_SPAN, CLIENT_SPAN);
+    }
+  }
+
+  @Test void illegalToSendWhenClosed() throws IOException {
+    try (PulsarSender sender = pulsar.newSenderBuilder(testName).build()) {
+      sender.close();
+      assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN)).isInstanceOf(
+          IllegalStateException.class);
+    }
+  }
+
+  /**
+   * The output of toString() on {@link BytesMessageSender} implementations appears in thread names
+   * created by {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other
+   * monitoring tools, care should be taken to ensure the toString() output is a reasonable length
+   * and does not contain sensitive information.
+   */
+  @Test void toStringContainsOnlySummaryInformation() throws IOException {
+    try (PulsarSender sender = pulsar.newSenderBuilder(testName).build()) {
+      assertThat(sender).hasToString(String.format(
+          "PulsarSender{clientProps={serviceUrl=%s}, producerProps=%s, messageProps=%s, topic=%s}",
+          pulsar.serviceUrl(),
+          new HashMap<>(),
+          new HashMap<>(),
+          testName));
+    }
+  }
+
+  void send(PulsarSender sender, Span... spans) {
+    SpanBytesEncoder bytesEncoder;
+    switch (sender.encoding()) {
+      case JSON:
+        bytesEncoder = SpanBytesEncoder.JSON_V2;
+        break;
+      case THRIFT:
+        bytesEncoder = SpanBytesEncoder.THRIFT;
+        break;
+      case PROTO3:
+        bytesEncoder = SpanBytesEncoder.PROTO3;
+        break;
+      default:
+        throw new UnsupportedOperationException("encoding: " + sender.encoding());
+    }
+    sender.send(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
+  }
+
+  byte[] readMessage(PulsarSender sender) throws Exception {
+    final CountDownLatch countDown = new CountDownLatch(1);
+    final AtomicReference<byte[]> result = new AtomicReference<>();
+
+    try (Consumer<byte[]> ignored = sender.client.newConsumer()
+        .topic(sender.topic)
+        .subscriptionName("zipkin-subscription")
+        .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+        .messageListener((consumer, message) -> {
+          try {
+            result.set(message.getData());
+            countDown.countDown();
+            consumer.acknowledge(message);
+          } catch (Exception e) {
+            consumer.negativeAcknowledge(message);
+          }
+        }).subscribe()) {
+
+      assertThat(countDown.await(10, TimeUnit.SECONDS))
+          .withFailMessage("Timed out waiting to read message.")
+          .isTrue();
+      assertThat(result)
+          .withFailMessage("Message data is null in Pulsar consumer.")
+          .isNotNull();
+      return result.get();
+    }
+  }
+}

--- a/pulsar-client/src/test/java/zipkin2/reporter/pulsar/PulsarContainer.java
+++ b/pulsar-client/src/test/java/zipkin2/reporter/pulsar/PulsarContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.pulsar;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import java.time.Duration;
+
+import static org.testcontainers.utility.DockerImageName.parse;
+
+final class PulsarContainer extends GenericContainer<PulsarContainer> {
+  static final Logger LOGGER = LoggerFactory.getLogger(PulsarContainer.class);
+  static final int BROKER_PORT = 6650;
+  static final int BROKER_HTTP_PORT = 8080;
+
+  PulsarContainer() {
+    super(parse("ghcr.io/openzipkin/zipkin-pulsar:3.4.3"));
+    withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
+    String cmd = "/pulsar/bin/apply-config-from-env.py /pulsar/conf/standalone.conf " +
+        "&& bin/pulsar standalone " +
+        "--no-functions-worker -nss";
+    withEnv("PULSAR_MEM", "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=1g"); // limit memory usage
+    waitStrategy = new HttpWaitStrategy()
+        .forPort(BROKER_HTTP_PORT)
+        .forStatusCode(200)
+        .forPath("/admin/v2/clusters")
+        .withStartupTimeout(Duration.ofSeconds(120));
+    withCommand("/bin/bash", "-c", cmd);
+    withLogConsumer(new Slf4jLogConsumer(LOGGER));
+  }
+
+  String serviceUrl() {
+    return "pulsar://" + getHost() + ":" + getMappedPort(BROKER_PORT);
+  }
+
+  PulsarSender.Builder newSenderBuilder(String topic) {
+    return PulsarSender.newBuilder().topic(topic).serviceUrl(serviceUrl());
+  }
+}

--- a/pulsar-client/src/test/resources/log4j2.properties
+++ b/pulsar-client/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=warn
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -12,6 +12,7 @@ Bean Factories exist for the following types:
 * URLConnectionSenderFactoryBean - for [zipkin-sender-urlconnection](../urlconnection)
 * AsyncZipkinSpanHandlerFactoryBean - for [brave](https://github.com/openzipkin/brave)
 * ZipkinSpanHandlerFactoryBeanTest - for [brave](https://github.com/openzipkin/brave) reporter bridge
+* PulsarSenderFactoryBean - for [zipkin-sender-pulsar-client](../pulsar-client)
 
 * Here's a basic example
 ```xml

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -117,6 +117,11 @@
       <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-pulsar-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spring-beans/src/it/spring_floor/pom.xml
+++ b/spring-beans/src/it/spring_floor/pom.xml
@@ -130,6 +130,12 @@
       <version>@log4j12.version@</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-pulsar-client</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/PulsarSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/PulsarSenderFactoryBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.beans;
+
+import io.opentelemetry.api.internal.StringUtils;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.pulsar.PulsarSender;
+
+import java.io.IOException;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class PulsarSenderFactoryBean extends AbstractFactoryBean {
+
+  String serviceUrl, topic;
+  Encoding encoding;
+  Integer messageMaxBytes;
+
+  @Override protected PulsarSender createInstance() {
+    PulsarSender.Builder builder = PulsarSender.newBuilder();
+    if (serviceUrl != null) builder.serviceUrl(serviceUrl);
+    if (topic != null) builder.topic(topic);
+    if (encoding != null) builder.encoding(encoding);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    return builder.build();
+  }
+
+  @Override public Class<? extends PulsarSender> getObjectType() {
+    return PulsarSender.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  @Override protected void destroyInstance(Object instance) throws IOException {
+    ((PulsarSender) instance).close();
+  }
+
+  public void setServiceUrl(String serviceUrl) {
+    this.serviceUrl = serviceUrl;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public void setEncoding(Encoding encoding) {
+    this.encoding = encoding;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/PulsarSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/PulsarSenderFactoryBeanTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.beans;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.pulsar.PulsarSender;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PulsarSenderFactoryBeanTest {
+  XmlBeans context;
+
+  @AfterEach void close() {
+    if (context != null) context.close();
+  }
+
+  @Test void serviceUrlAndTopic() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.PulsarSenderFactoryBean\">\n"
+        + "  <property name=\"serviceUrl\" value=\"pulsar://localhost:6650\"/>\n"
+        + "  <property name=\"topic\" value=\"zhouzixin\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", PulsarSender.class))
+        .usingRecursiveComparison()
+        .isEqualTo(PulsarSender.newBuilder()
+            .serviceUrl("pulsar://localhost:6650")
+            .topic("zhouzixin").build());
+  }
+
+  @Test void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.PulsarSenderFactoryBean\">\n"
+        + "  <property name=\"serviceUrl\" value=\"pulsar://localhost:6650\"/>\n"
+        + "  <property name=\"topic\" value=\"zhouzixin\"/>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"1024\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", PulsarSender.class))
+        .extracting("messageMaxBytes")
+        .isEqualTo(1024);
+  }
+
+  @Test void encoding() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.PulsarSenderFactoryBean\">\n"
+        + "  <property name=\"serviceUrl\" value=\"pulsar://localhost:6650\"/>\n"
+        + "  <property name=\"topic\" value=\"zhouzixin\"/>\n"
+        + "  <property name=\"encoding\" value=\"PROTO3\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", PulsarSender.class))
+        .extracting("encoding")
+        .isEqualTo(Encoding.PROTO3);
+  }
+
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context = new XmlBeans(""
+          + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.PulsarSenderFactoryBean\">\n"
+          + "  <property name=\"serviceUrl\" value=\"pulsar://localhost:6650\"/>\n"
+          + "  <property name=\"topic\" value=\"zhouzixin\"/>\n"
+          + "</bean>"
+      );
+
+      PulsarSender sender = context.getBean("sender", PulsarSender.class);
+      context.close();
+
+      sender.send(Arrays.asList(new byte[]{'{', '}'}));
+    });
+  }
+}

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-urlconnection</artifactId>


### PR DESCRIPTION
- Add Pulsar sender
- Add tests for all changes.
- Add corresponding documentation

Here are the results of the benchmarks test on my Mac:
```shell
Benchmark                                        (messageMaxBytes)   Mode  Cnt    Score   Error  Units
RabbitMQSenderBenchmarks.report                              65536  thrpt   15  938.941 ± 2.591  ops/s
RabbitMQSenderBenchmarks.report:messages                     65536  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:messagesDropped              65536  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:spans                        65536  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report                             500000  thrpt   15  939.077 ± 3.733  ops/s
RabbitMQSenderBenchmarks.report:messages                    500000  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:messagesDropped             500000  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:spans                       500000  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report                            5242880  thrpt   15  939.080 ± 2.810  ops/s
RabbitMQSenderBenchmarks.report:messages                   5242880  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:messagesDropped            5242880  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:spans                      5242880  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report                           16777216  thrpt   15  939.940 ± 2.797  ops/s
RabbitMQSenderBenchmarks.report:messages                  16777216  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:messagesDropped           16777216  thrpt   15      ≈ 0          ops/s
RabbitMQSenderBenchmarks.report:spans                     16777216  thrpt   15      ≈ 0          ops/s

Benchmark                                     (messageMaxBytes)   Mode  Cnt    Score    Error  Units
KafkaSenderBenchmarks.report                              65536  thrpt   15  938.911 ±  3.421  ops/s
KafkaSenderBenchmarks.report:messages                     65536  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:messagesDropped              65536  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:spans                        65536  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report                             500000  thrpt   15  939.231 ±  2.939  ops/s
KafkaSenderBenchmarks.report:messages                    500000  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:messagesDropped             500000  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:spans                       500000  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report                            5242880  thrpt   15  934.861 ±  7.149  ops/s
KafkaSenderBenchmarks.report:messages                   5242880  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:messagesDropped            5242880  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:spans                      5242880  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report                           16777216  thrpt   15  938.820 ± 13.087  ops/s
KafkaSenderBenchmarks.report:messages                  16777216  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:messagesDropped           16777216  thrpt   15      ≈ 0           ops/s
KafkaSenderBenchmarks.report:spans                     16777216  thrpt   15      ≈ 0           ops/s

Benchmark                                      (messageMaxBytes)   Mode  Cnt    Score   Error  Units
PulsarSenderBenchmarks.report                              65536  thrpt   15  946.973 ± 4.041  ops/s
PulsarSenderBenchmarks.report:messages                     65536  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:messagesDropped              65536  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:spans                        65536  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report                             500000  thrpt   15  947.886 ± 3.588  ops/s
PulsarSenderBenchmarks.report:messages                    500000  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:messagesDropped             500000  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:spans                       500000  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report                            5242880  thrpt   15  946.711 ± 2.599  ops/s
PulsarSenderBenchmarks.report:messages                   5242880  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:messagesDropped            5242880  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:spans                      5242880  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report                           16777216  thrpt   15  947.860 ± 3.568  ops/s
PulsarSenderBenchmarks.report:messages                  16777216  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:messagesDropped           16777216  thrpt   15      ≈ 0          ops/s
PulsarSenderBenchmarks.report:spans                     16777216  thrpt   15      ≈ 0          ops/s
```